### PR TITLE
formData: should return array of values when the name of checkbox has…

### DIFF
--- a/lib/cape/component.js
+++ b/lib/cape/component.js
@@ -234,7 +234,7 @@ Cape.extend(_Internal.prototype, {
     }
   },
   serializeForms: function() {
-    var forms, elements, i, j, elem, segments, lastSegment, obj, o;
+    var forms, elements, i, j, elem, segments, lastSegment, obj, o, name;
 
     this.forms = {};
     forms = this.main.root.getElementsByTagName('form');
@@ -246,7 +246,18 @@ Cape.extend(_Internal.prototype, {
         if (elem.name && (elem.value !== undefined)) {
           if ((elem.type === 'checkbox' || elem.type === 'radio') && !elem.checked)
             continue;
-          obj[elem.name] = elem.value;
+          if (elem.name.slice(-2) === '[]') {
+            name = elem.name.slice(0, -2);
+            if (!Array.isArray(obj[name])) {
+              obj[name] = [];
+            }
+            if (elem.type !== 'hidden') {
+              obj[name].push(elem.value);
+            }
+          }
+          else {
+            obj[elem.name] = elem.value;
+          }
         }
       }
       if (forms[i].getAttribute('name')) {

--- a/test/spec/component_test.js
+++ b/test/spec/component_test.js
@@ -424,6 +424,44 @@ describe('Component', function() {
       expect(params.title).to.equal('A');
       expect(params.name).to.equal('B');
     })
+    it('should return array of values when the name of checkbox has "[]" in the end', function() {
+      var Klass, component, params;
+
+      Klass = Cape.createComponentClass({
+        render: function(m) {
+          m.form(function(m) {
+            m.checkBox('types[]', { value: 'a', checked: true });
+            m.checkBox('types[]', { value: 'b', checked: true });
+          });
+        }
+      })
+
+      component = new Klass();
+      component.mount('target');
+      params = component.formData();
+      expect(Array.isArray(params.types)).to.equal(true);
+      expect(params.types.length).to.equal(2);
+      expect(params.types[0]).to.equal('a');
+      expect(params.types[1]).to.equal('b');
+    })
+    it('should return string when the name of checkbox does not have "[]" in the end', function() {
+      var Klass, component, params;
+
+      Klass = Cape.createComponentClass({
+        render: function(m) {
+          m.form(function(m) {
+            m.checkBox('types', { value: 'a', checked: true });
+            m.checkBox('types', { value: 'b', checked: true });
+          });
+        }
+      })
+
+      component = new Klass();
+      component.mount('target');
+      params = component.formData();
+      expect(Array.isArray(params.types)).to.equal(false);
+      expect(params.types).to.equal('b');
+    })
   })
 
   describe('paramsFor', function() {


### PR DESCRIPTION
CapeJs does not correspond to the multiple checkboxes in formData.
I change the function, #serializeForms, that is the '[]' specified to the suffix of the name attribute as RoR, the value is returned as a array.